### PR TITLE
remove read_only attribute

### DIFF
--- a/django/project/serializers.py
+++ b/django/project/serializers.py
@@ -1038,7 +1038,7 @@ class SolutionSerializer(serializers.ModelSerializer):
         write_only=True,
         required=False,
     )
-    people_reached = serializers.IntegerField(read_only=True)
+    people_reached = serializers.IntegerField()
     problem_statements = ProblemStatementSerializer(many=True, required=False)
     portfolios = PortfolioSerializer(many=True, required=False)
 


### PR DESCRIPTION
# Description

Correct "people_reached" in serializers.py. We want not only read_only attribute but write atttibute. So i removed the specific attribute  

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
