### PR TITLE
Feature/163742/enable ootb monitoring capabilities

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -7,6 +7,7 @@ asn1crypto==0.24.0
 astroid==2.3.3
 atomicwrites==1.1.5
 attrs==18.1.0
+azure-monitor-opentelemetry==1.0.0b13
 backcall==0.1.0
 bcrypt==3.1.4
 behave==1.2.6

--- a/django/tiip/settings.py
+++ b/django/tiip/settings.py
@@ -403,9 +403,8 @@ if ENVIRONMENT in ["dev", "tst", "uat", "prd"]:
     from .settings_deployed import *
 
 # Azure Monitor OpenTelemetry
-if ENVIRONMENT in ['dev']:
+if ENVIRONMENT in ['tst']:
     from azure.monitor.opentelemetry import configure_azure_monitor
-    from opentelemetry import trace
 
     # Fetch the connection string from the environment variable
     APPLICATIONINSIGHTS_CONNECTION_STRING = os.environ.get(
@@ -413,4 +412,3 @@ if ENVIRONMENT in ['dev']:
 
     if APPLICATIONINSIGHTS_CONNECTION_STRING:  # Ensure the connection string exists
         configure_azure_monitor(APPLICATIONINSIGHTS_CONNECTION_STRING)
-

--- a/django/tiip/settings.py
+++ b/django/tiip/settings.py
@@ -188,7 +188,6 @@ STATIC_URL = '/static/'
 STATIC_ROOT = '/usr/share/django/static'
 
 MEDIA_ROOT = '/usr/share/django/media'
-# MEDIA_ROOT = '/usr/share/nginx/html/media'
 MEDIA_URL = '/media/'
 
 FILE_UPLOAD_PERMISSIONS = 0o644
@@ -402,3 +401,16 @@ EMAIL_VALIDATOR_REGEX = r'{}'.format(
 # Import the setting_azure settings only in the Azure environments
 if ENVIRONMENT in ["dev", "tst", "uat", "prd"]:
     from .settings_deployed import *
+
+# Azure Monitor OpenTelemetry
+if ENVIRONMENT in ['dev']:
+    from azure.monitor.opentelemetry import configure_azure_monitor
+    from opentelemetry import trace
+
+    # Fetch the connection string from the environment variable
+    APPLICATIONINSIGHTS_CONNECTION_STRING = os.environ.get(
+        'APPLICATIONINSIGHTS_CONNECTION_STRING', default='')
+
+    if APPLICATIONINSIGHTS_CONNECTION_STRING:  # Ensure the connection string exists
+        configure_azure_monitor(APPLICATIONINSIGHTS_CONNECTION_STRING)
+

--- a/django/tiip/settings.py
+++ b/django/tiip/settings.py
@@ -403,7 +403,7 @@ if ENVIRONMENT in ["dev", "tst", "uat", "prd"]:
     from .settings_deployed import *
 
 # Azure Monitor OpenTelemetry
-if ENVIRONMENT in ['tst']:
+if ENVIRONMENT in ['dev']:
     from azure.monitor.opentelemetry import configure_azure_monitor
 
     # Fetch the connection string from the environment variable


### PR DESCRIPTION
# Description

Add the python library needed to enable Azure Monitor OpenTelemetry and modify the application settings.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This item cannot be tested locally. It needs to be merged in dev and then communicate with UNICEF to confirm that data is flowing to Application Insights

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
